### PR TITLE
#54 integration meetupRequest backend services

### DIFF
--- a/backend/src/controller/meetupController.ts
+++ b/backend/src/controller/meetupController.ts
@@ -77,7 +77,7 @@ export class MeetupController extends BaseController {
                 return;
             }
             res.status(400);
-            res.json(MeetupsFactory.createGetMeetupRespons(false, 'meetup not exits.'));
+            res.json(MeetupsFactory.createGetMeetupRespons(false, 'meetup not exists.'));
             return;
         }).catch((err) => {
             this.logger.error(err.toString());

--- a/backend/src/controller/meetupRequestController.ts
+++ b/backend/src/controller/meetupRequestController.ts
@@ -19,7 +19,7 @@ export class MeetupRequestController extends BaseController {
                 return;
             }
             res.status(400);
-            res.json(MeetupRequestsFactory.createGetMeetupRequestResponse(false, 'meetup-request not exits.'));
+            res.json(MeetupRequestsFactory.createGetMeetupRequestResponse(false, 'meetup-request not exists.'));
             return;
         }).catch((err) => {
             this.logger.error(err.toString());

--- a/backend/src/controller/meetupRequestController.ts
+++ b/backend/src/controller/meetupRequestController.ts
@@ -121,13 +121,14 @@ export class MeetupRequestController extends BaseController {
         // Check if meetup-request exists
         DBMeetupRequest.findById(req.params.id).then((dbMeetupReq) => {
             if (dbMeetupReq) {
+                // todo: Hier könnte noch überprüft werden ob der Aufrufer auch owner des Request ist -> wäre für scharfen Betrieb notwendig
                 // Removes meetup-request
                 dbMeetupReq.remove();
                 res.json(MeetupRequestsFactory.createDeleteMeetupRequestResponse(true, 'successfully deleted meetup-request'));
                 return;
             }
             res.status(400);
-            res.json(MeetupRequestsFactory.createDeleteMeetupRequestResponse(false, 'meetup-request not exits.'));
+            res.json(MeetupRequestsFactory.createDeleteMeetupRequestResponse(false, 'meetup-request not exists.'));
             return;
         }).catch((err) => {
             this.logger.error(err.toString());

--- a/backend/src/tests/meetup-request/meetup-requests.spec.ts
+++ b/backend/src/tests/meetup-request/meetup-requests.spec.ts
@@ -122,7 +122,7 @@ describe('Test /meetupRequests', () => {
                             .get(`${baseTest.route}meetup-requests/${meetupRequestToDel.id}`)
                             .set({authorization: baseTest.token})
                             .end((err, res) => {
-                                baseTest.assertFailed(res, 400, 'meetup not exits.');
+                                baseTest.assertFailed(res, 400, 'meetup-request not exists.');
                                 done();
                             })
                     })

--- a/frontend/src/app/core/AppDialogService.ts
+++ b/frontend/src/app/core/AppDialogService.ts
@@ -1,0 +1,25 @@
+import {Injectable} from '@angular/core';
+import {InfoPopupComponent} from '../material/info-popup/info-popup.component';
+import {MatDialog} from '@angular/material';
+import {HttpErrorResponse} from '@angular/common/http';
+
+@Injectable()
+export class AppDialogService {
+
+  constructor(private dialog: MatDialog) {
+  }
+
+  showError(message: string) {
+    console.log('Error occured: ', message);
+    const dialogRef = this.dialog.open(InfoPopupComponent,
+      {data: {infoText: message, infoTitle: 'appDialogService.errorTitle'}});
+  }
+
+
+  showServerError(response: HttpErrorResponse) {
+    const message = `status: ${response.status} /  message: ${response.error.message}`;
+    console.log('Server Error occured: ', message);
+    const dialogRef = this.dialog.open(InfoPopupComponent,
+      {data: {infoText: message, infoTitle: 'appDialogService.serverErrorTitle'}});
+  }
+}

--- a/frontend/src/app/core/business.service.ts
+++ b/frontend/src/app/core/business.service.ts
@@ -5,16 +5,21 @@ import {MockService} from './mock.service';
 import {AppStateService} from './app-state.service';
 import {
   AuthFactory,
-  ILoginResponse,
-  IRegisterResponse,
-  IUpdateProfileResponse,
   Chat,
   Hall,
+  IDeleteMeetupRequestResponse,
+  ILoginResponse,
+  IRegisterResponse,
+  IUpdateMeetupRequestResponse,
+  IUpdateProfileResponse,
   Meetup,
   MeetupRequest,
-  User,
-  SearchDto
+  MeetupRequestsFactory,
+  RequestStatus,
+  SearchDto,
+  User
 } from '@chumm-uffa/interface';
+
 
 /**
  * Hier kann Businesslogik rein.
@@ -40,7 +45,7 @@ export class BusinessService {
    * @returns {Observable<IRegisterResponse>}
    */
   register(user: User): Observable<IRegisterResponse> {
-    return this.resourceService.register(AuthFactory.createRegisterRequest( user ));
+    return this.resourceService.register(AuthFactory.createRegisterRequest(user));
   }
 
   /**
@@ -99,8 +104,10 @@ export class BusinessService {
     return this.mockService.loadRequests(meetupId);
   }
 
-  updateRequest(request: MeetupRequest): Observable<MeetupRequest> {
-    return this.mockService.updateRequest(request);
+  updateRequest(request: MeetupRequest, state: RequestStatus): Observable<IUpdateMeetupRequestResponse> {
+    const mr = JSON.parse(JSON.stringify(request));
+    mr.status = state;
+    return this.resourceService.updateRequest(MeetupRequestsFactory.createUpdateMeetupRequestRequest(mr));
   }
 
   loadChatsByMeetupId(meetupId: string): Observable<Chat[]> {
@@ -117,16 +124,17 @@ export class BusinessService {
     return this.mockService.searchMeetup(searchDto);
   }
 
-  requestForParticipation(meetupId: string): Observable<boolean> {
-    return this.mockService.requestForParticipation(meetupId);
+  requestForParticipation(meetup: Meetup): Observable<IDeleteMeetupRequestResponse> {
+    const request = MeetupRequestsFactory.createCreateMeetupRequestRequest(new MeetupRequest(null, this.appState.loggedInUser, meetup));
+    return this.resourceService.createMeetupRequest(request);
   }
 
   deleteMeetup(meetupId: string): Observable<boolean> {
     return this.mockService.deleteMeetup(meetupId);
   }
 
-  deleteRequest(requestId: string): Observable<boolean> {
-    return this.mockService.deleteRequest(requestId);
+  deleteRequest(requestId: string): Observable<IDeleteMeetupRequestResponse> {
+    return this.resourceService.deleteRequest(requestId);
   }
 }
 

--- a/frontend/src/app/core/core.module.ts
+++ b/frontend/src/app/core/core.module.ts
@@ -5,10 +5,12 @@ import {HttpClientModule} from '@angular/common/http';
 import {AppStateService} from './app-state.service';
 import {MockService} from './mock.service';
 import {AuthGuard} from './AuthGuard';
+import {MaterialModule} from '../material/material.module';
+import {AppDialogService} from './AppDialogService';
 
 @NgModule({
   imports: [
-    HttpClientModule
+    HttpClientModule, MaterialModule
 
   ],
   providers: [
@@ -16,7 +18,8 @@ import {AuthGuard} from './AuthGuard';
     BusinessService,
     AppStateService,
     MockService,
-    AuthGuard
+    AuthGuard,
+    AppDialogService
   ]
 })
 export class CoreModule {

--- a/frontend/src/app/core/mock.service.ts
+++ b/frontend/src/app/core/mock.service.ts
@@ -2,8 +2,28 @@ import {Injectable} from '@angular/core';
 import {ResourceServiceInterface} from './resource.service';
 import {Observable} from 'rxjs/Observable';
 import {of} from 'rxjs/observable/of';
-import {ILoginRequest, IRegisterResponse, ILoginResponse, IRegisterRequest, IUpdateProfileRequest, IUpdateProfileResponse,
-  User, Hall, Chat, Meetup, MeetupRequest, RequestStatus, SearchDto, AuthFactory} from '@chumm-uffa/interface';
+import {
+  AuthFactory,
+  Chat,
+  Hall,
+  ICreateMeetupRequestRequest,
+  ICreateMeetupRequestResponse,
+  IDeleteMeetupRequestResponse,
+  ILoginRequest,
+  ILoginResponse,
+  IRegisterRequest,
+  IRegisterResponse,
+  IUpdateMeetupRequestRequest,
+  IUpdateMeetupRequestResponse,
+  IUpdateProfileRequest,
+  IUpdateProfileResponse,
+  Meetup,
+  MeetupRequest,
+  MeetupRequestsFactory,
+  RequestStatus,
+  SearchDto,
+  User
+} from '@chumm-uffa/interface';
 
 /**
  * Mock for the resource service
@@ -36,7 +56,7 @@ export class MockService implements ResourceServiceInterface {
   }
 
   login(request: ILoginRequest): Observable<ILoginResponse> {
-    return of(AuthFactory.createLoginResponse(true, '', 'token', this._users[0] ));
+    return of(AuthFactory.createLoginResponse(true, '', 'token', this._users[0]));
   }
 
   getMeetUps(user: User): Observable<Meetup[]> {
@@ -59,8 +79,9 @@ export class MockService implements ResourceServiceInterface {
   /**
    * Es wird nur der Request, nicht aber der User oder das Meetup aktualisiert.
    */
-  updateRequest(request: MeetupRequest): Observable<MeetupRequest> {
-    return of(new MeetupRequest(request.id, request.participant, request.meetup, request.status));
+  updateRequest(request: IUpdateMeetupRequestRequest): Observable<IUpdateMeetupRequestResponse> {
+    const mr = new MeetupRequest(request.request.id, request.request.participant, request.request.meetup, request.request.status)
+    return of(MeetupRequestsFactory.createUpdateMeetupRequestResponse(true, '', mr));
   }
 
   loadChatsByMeetupId(meetupId: string): Observable<Chat[]> {
@@ -75,8 +96,8 @@ export class MockService implements ResourceServiceInterface {
     return of(this._meetups);
   }
 
-  requestForParticipation(meetupId: string): Observable<boolean> {
-    return of(true);
+  createMeetupRequest(request: ICreateMeetupRequestRequest): Observable<ICreateMeetupRequestResponse> {
+    return of(MeetupRequestsFactory.createCreateMeetupRequestResponse(true, ''));
   }
 
   deleteMeetup(meetupId: string): Observable<boolean> {
@@ -84,9 +105,9 @@ export class MockService implements ResourceServiceInterface {
     return of(true);
   }
 
-  deleteRequest(requestId: string): Observable<boolean> {
+  deleteRequest(requestId: string): Observable<IDeleteMeetupRequestResponse> {
     this._meetupRequest = this._meetupRequest.filter(mu => mu.id !== requestId);
-    return of(true);
+    return of(MeetupRequestsFactory.createDeleteMeetupRequestResponse(true, ''));
   }
 
   /**
@@ -138,10 +159,10 @@ export class MockService implements ResourceServiceInterface {
 
   private generateUsers() {
     this._users = [];
-    this._users.push(new User('WilliCliffhanger', '', 'm', '', '85'));
-    this._users.push(new User('BarbaraChumNidUffa', '', 'f', '', '45'));
-    this._users.push(new User('UrsChrumBei', '', 'm', '', '72'));
-    this._users.push(new User('PetraImmerBlau', '', 'f', '', '85'));
+    this._users.push(new User('1', 'WilliCliffhanger', '', 'm', '', '85'));
+    this._users.push(new User('2', 'Eder', '', 'f', '', '45'));
+    this._users.push(new User('3', 'UrsChrumBei', '', 'm', '', '72'));
+    this._users.push(new User('4', 'PetraImmerBlau', '', 'f', '', '85'));
   }
 
   /**
@@ -177,13 +198,13 @@ export class MockService implements ResourceServiceInterface {
    */
   private generateChats() {
     this._chats = [];
-    this._chats.push(new Chat('1','Arschgeige', this._users[1], new Date(2017, 8, 25, 12, 45)));
-    this._chats.push(new Chat('2','hab dich auch lieb', this._users[2], new Date(2017, 9, 8, 14, 40)));
-    this._chats.push(new Chat('3','wa wotsch', this._users[3], new Date(2017, 6, 15, 16, 5)));
-    this._chats.push(new Chat('4','cha nöd', this._users[0], new Date(2017, 5, 6, 15, 5)));
-    this._chats.push(new Chat('5','kei Bock', this._users[1], new Date(2017, 4, 5, 8, 4)));
-    this._chats.push(new Chat('6','nöd gsicheret', this._users[0], new Date(2017, 2, 5, 10, 5)));
-    this._chats.push(new Chat('7','freie Fall', this._users[3], new Date(2017, 11, 2, 2, 5)));
-    this._chats.push(new Chat('8','we are the champignions', this._users[0], new Date(2017, 10, 2, 12, 42)));
+    this._chats.push(new Chat('1', 'Arschgeige', this._users[1], new Date(2017, 8, 25, 12, 45)));
+    this._chats.push(new Chat('2', 'hab dich auch lieb', this._users[2], new Date(2017, 9, 8, 14, 40)));
+    this._chats.push(new Chat('3', 'wa wotsch', this._users[3], new Date(2017, 6, 15, 16, 5)));
+    this._chats.push(new Chat('4', 'cha nöd', this._users[0], new Date(2017, 5, 6, 15, 5)));
+    this._chats.push(new Chat('5', 'kei Bock', this._users[1], new Date(2017, 4, 5, 8, 4)));
+    this._chats.push(new Chat('6', 'nöd gsicheret', this._users[0], new Date(2017, 2, 5, 10, 5)));
+    this._chats.push(new Chat('7', 'freie Fall', this._users[3], new Date(2017, 11, 2, 2, 5)));
+    this._chats.push(new Chat('8', 'we are the champignions', this._users[0], new Date(2017, 10, 2, 12, 42)));
   }
 }

--- a/frontend/src/app/core/resource.service.ts
+++ b/frontend/src/app/core/resource.service.ts
@@ -3,19 +3,26 @@ import {Observable} from 'rxjs/Observable';
 import {HttpClient} from '@angular/common/http';
 
 import {
+  Chat,
+  ICreateMeetupRequestRequest,
+  ICreateMeetupRequestResponse,
+  IDeleteMeetupRequestResponse,
   ILoginRequest,
-  IRegisterResponse,
   ILoginResponse,
   IRegisterRequest,
+  IRegisterResponse,
+  IUpdateMeetupRequestRequest,
+  IUpdateMeetupRequestResponse,
   IUpdateProfileRequest,
   IUpdateProfileResponse,
-  User,
-  Chat,
   Meetup,
   MeetupRequest,
-  Version,
-  SearchDto} from '@chumm-uffa/interface';
-import {AppStateService} from "./app-state.service";
+  SearchDto,
+  User,
+  Version
+} from '@chumm-uffa/interface';
+import {AppStateService} from './app-state.service';
+
 
 /**
  * Resource service interface
@@ -37,7 +44,7 @@ export interface ResourceServiceInterface {
 
   loadRequests(meetupId: string): Observable<MeetupRequest[]>;
 
-  updateRequest(request: MeetupRequest): Observable<MeetupRequest>;
+  updateRequest(request: IUpdateMeetupRequestRequest): Observable<IUpdateMeetupRequestResponse>;
 
   loadChatsByMeetupId(meetupId: string): Observable<Chat[]>;
 
@@ -45,11 +52,11 @@ export interface ResourceServiceInterface {
 
   searchMeetup(searchDto: SearchDto): Observable<Meetup[]>;
 
-  requestForParticipation(meetupId: string): Observable<boolean>;
+  createMeetupRequest(request: ICreateMeetupRequestRequest): Observable<ICreateMeetupRequestResponse>;
 
   deleteMeetup(meetupId: string): Observable<boolean>;
 
-  deleteRequest(requestId: string): Observable<boolean>;
+  deleteRequest(requestId: string): Observable<IDeleteMeetupRequestResponse>;
 
   saveUser(user: IUpdateProfileRequest): Observable<IUpdateProfileResponse>;
 }
@@ -139,8 +146,8 @@ export class ResourceService implements ResourceServiceInterface {
   /**
    * Es wird nur der Request, nicht aber der User oder das Meetup aktualisiert.
    */
-  updateRequest(request: MeetupRequest): Observable<MeetupRequest> {
-    throw new Error('Method not implemented.');
+  updateRequest(request: IUpdateMeetupRequestRequest): Observable<IUpdateMeetupRequestResponse> {
+    return this.http.put<IUpdateMeetupRequestResponse>(this.urlDemo + `meetup-requests/${request.request.id}`, request);
   }
 
   loadChatsByMeetupId(meetupId: string): Observable<Chat[]> {
@@ -155,16 +162,16 @@ export class ResourceService implements ResourceServiceInterface {
     throw new Error('Method not implemented.');
   }
 
-  requestForParticipation(meetupId: string): Observable<boolean> {
-    throw new Error('Method not implemented.');
+  createMeetupRequest(request: ICreateMeetupRequestRequest): Observable<ICreateMeetupRequestResponse> {
+    return this.http.post<ICreateMeetupRequestResponse>(this.urlDemo + 'meetup-requests', request);
   }
 
   deleteMeetup(meetupId: string): Observable<boolean> {
     throw new Error('Method not implemented.');
   }
 
-  deleteRequest(requestId: string): Observable<boolean> {
-    throw new Error('Method not implemented.');
+  deleteRequest(requestId: string): Observable<IDeleteMeetupRequestResponse> {
+    return this.http.delete<ICreateMeetupRequestResponse>(`${this.urlDemo}meetup-requests/${requestId}`);
   }
 
   /**
@@ -173,6 +180,6 @@ export class ResourceService implements ResourceServiceInterface {
    * @returns {Observable<any>}
    */
   saveUser(request: IUpdateProfileRequest): Observable<IUpdateProfileResponse> {
-        return this.http.put<IUpdateProfileResponse>(this.urlDemo + 'auth/profile', request);
+    return this.http.put<IUpdateProfileResponse>(this.urlDemo + 'auth/profile', request);
   }
 }

--- a/frontend/src/app/i18n/de.json
+++ b/frontend/src/app/i18n/de.json
@@ -23,7 +23,7 @@
     "franz": "FR",
     "logout": "Abmelden",
     "link": {
-      "home":"Startseite",
+      "home": "Startseite",
       "updateUser": "Benutzerprofil",
       "myMeetups": "Meine Meetups",
       "newMeetup": "Meetup erstellen",
@@ -105,7 +105,7 @@
     "sex": "Geschlecht",
     "weight": "Körpergewicht",
     "m": "männlich",
-    "w": "weiblich",
+    "f": "weiblich",
     "kg": "kg"
   },
   "chat": {
@@ -168,7 +168,8 @@
     "signOff": "abmelden",
     "dialog": {
       "signOffTitle": "Abmelden",
-      "signOffText": "Sie melden sich vom Meetup ab!"
+      "signOffText": "Sie melden sich vom Meetup ab!",
+      "error": "Server Error"
     }
   },
   "confirmDialog": {
@@ -177,5 +178,9 @@
   },
   "infoPopup": {
     "ok": "OK"
+  },
+  "appDialogService": {
+    "serverErrorTitle": "Server Error",
+    "errorTitle": "Error"
   }
 }

--- a/frontend/src/app/i18n/fr.json
+++ b/frontend/src/app/i18n/fr.json
@@ -23,7 +23,7 @@
     "franz": "FR_FR",
     "logout": "Abmelden_FR",
     "link": {
-      "home":"Startseite_FR",
+      "home": "Startseite_FR",
       "updateUser": "Benutzerprofil_FR",
       "myMeetups": "Meine Meetups_FR",
       "newMeetup": "Meetup erstellen_FR",
@@ -105,7 +105,7 @@
     "sex": "Geschlecht_FR",
     "weight": "Körpergewicht_FR",
     "m": "männlich_FR",
-    "w": "weiblich_FR",
+    "f": "weiblich_FR",
     "kg": "kg_FR"
   },
   "chat": {
@@ -168,7 +168,8 @@
     "signOff": "abmelden_FR",
     "dialog": {
       "signOffTitle": "Abmelden_FR",
-      "signOffText": "Sie melden sich vom Meetup ab!_FR"
+      "signOffText": "Sie melden sich vom Meetup ab!_FR",
+      "error": "Server Error"
     }
   },
   "confirmDialog": {
@@ -177,5 +178,9 @@
   },
   "infoPopup": {
     "ok": "OK_FR"
+  },
+  "appDialogService": {
+    "serverErrorTitle": "Server Error",
+    "errorTitle": "Error"
   }
 }

--- a/frontend/src/app/meetup-detail/participant/participant.component.ts
+++ b/frontend/src/app/meetup-detail/participant/participant.component.ts
@@ -1,6 +1,7 @@
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, Input} from '@angular/core';
 import {MeetupRequest, RequestStatus} from '@chumm-uffa/interface';
 import {BusinessService} from '../../core/business.service';
+import {AppDialogService} from '../../core/AppDialogService';
 
 @Component({
   selector: 'app-participant',
@@ -16,11 +17,13 @@ export class ParticipantComponent {
 
   requestStatus = RequestStatus;
 
-  constructor(private businesService: BusinessService) {
+  constructor(private businesService: BusinessService, private appDialogService: AppDialogService) {
   }
 
   setState(state: RequestStatus): void {
-    this.meetupRequest.status = state;
-    this.businesService.updateRequest(this.meetupRequest).subscribe(mrq => this.meetupRequest = mrq);
+    this.businesService.updateRequest(this.meetupRequest, state).subscribe(res =>
+        res.success ? this.meetupRequest = res.request : this.appDialogService.showError(res.message),
+      err => this.appDialogService.showServerError(err)
+    );
   }
 }

--- a/frontend/src/app/meetup-detail/participant/participant.html
+++ b/frontend/src/app/meetup-detail/participant/participant.html
@@ -1,6 +1,6 @@
 <div class="participant">
   <label>{{meetupRequest.participant.username}}</label>
-  <label>{{meetupRequest.status | translate}}</label>
+  <label *ngIf="showStateButtons">{{meetupRequest.status | translate}}</label>
   <button *ngIf="showStateButtons" (click)="setState(requestStatus.ACCEPT)">{{'participant.accept' | translate}}</button>
   <button *ngIf="showStateButtons" (click)="setState(requestStatus.DECLINED)"> {{'participant.decline' | translate}}</button>
 </div>

--- a/frontend/src/app/mymeetups/open-requests/open-requests.component.ts
+++ b/frontend/src/app/mymeetups/open-requests/open-requests.component.ts
@@ -4,6 +4,7 @@ import {Hall, Meetup, MeetupRequest} from '@chumm-uffa/interface';
 import {Util} from '../../shared/util';
 import {MatDialog} from '@angular/material';
 import {ConfirmDialogComponent} from '../../material/confirm-dialog/confirm-dialog.component';
+import {AppDialogService} from '../../core/AppDialogService';
 
 @Component({
   selector: 'app-open-requests',
@@ -15,7 +16,8 @@ export class OpenRequestsComponent implements OnInit {
   halls: Hall[] = [];
 
   constructor(private businessService: BusinessService,
-              private dialog: MatDialog) {
+              private dialog: MatDialog,
+              private appDialogService: AppDialogService) {
   }
 
   ngOnInit() {
@@ -45,7 +47,11 @@ export class OpenRequestsComponent implements OnInit {
 
     dialogRef.afterClosed().subscribe(result => {
       if (result === 'yes') {
-        this.businessService.deleteRequest(requestId).subscribe(_ => this.getMeetupRequests());
+        this.businessService.deleteRequest(requestId).subscribe(res => {
+            res.success ? this.getMeetupRequests() : this.appDialogService.showError(res.message);
+          },
+          err => this.appDialogService.showServerError(err)
+        );
       }
     });
   }

--- a/frontend/src/app/search/search.component.ts
+++ b/frontend/src/app/search/search.component.ts
@@ -9,6 +9,7 @@ import {Hall, Meetup} from '@chumm-uffa/interface';
 
 import {MatDialog, MatTableDataSource} from '@angular/material';
 import {InfoPopupComponent} from '../material/info-popup/info-popup.component';
+import {AppDialogService} from '../core/AppDialogService';
 
 @Component({
   selector: 'app-search',
@@ -25,7 +26,8 @@ export class SearchComponent implements OnInit {
 
   constructor(private searchFormService: SearchFormService,
               private businessService: BusinessService,
-              private dialog: MatDialog) {
+              private dialog: MatDialog,
+              private appDialogService: AppDialogService) {
   }
 
   ngOnInit() {
@@ -46,14 +48,16 @@ export class SearchComponent implements OnInit {
     }
   }
 
-  requestForParticipation(event, meetupId: string): void {
+  requestForParticipation(event, meetupId: Meetup): void {
     event.stopPropagation();  // prevent link action
-    this.businessService.requestForParticipation(meetupId).subscribe(ack => {
-      if (ack) {
-        this.dialog.open(InfoPopupComponent,
-          {data: {infoText: 'Deine Anfrage wurde dem Meetup Owner mitgeteilt.', infoTitle: 'Anfrage'}});
-      }
-    });
+    this.businessService.requestForParticipation(meetupId).subscribe(res => {
+        if (res.success) {
+          this.dialog.open(InfoPopupComponent,
+            {data: {infoText: 'Deine Anfrage wurde dem Meetup Owner mitgeteilt.', infoTitle: 'Anfrage'}});
+        }
+      },
+      err => this.appDialogService.showServerError(err)
+    );
   }
 
   isIndoor(): boolean {

--- a/frontend/src/app/search/search.html
+++ b/frontend/src/app/search/search.html
@@ -81,7 +81,7 @@
     <!-- Register Column -->
     <ng-container matColumnDef="register">
       <mat-header-cell *matHeaderCellDef></mat-header-cell>
-      <mat-cell *matCellDef="let meetup"> <button mat-raised-button color="primary" (click)="requestForParticipation($event, meetup.id)">{{'search.startRequest' | translate}}</button> </mat-cell>
+      <mat-cell *matCellDef="let meetup"> <button mat-raised-button color="primary" (click)="requestForParticipation($event, meetup)">{{'search.startRequest' | translate}}</button> </mat-cell>
     </ng-container>
     <mat-header-row *matHeaderRowDef="columnDefinition"></mat-header-row>
     <mat-row *matRowDef="let row; columns: columnDefinition;"></mat-row>


### PR DESCRIPTION
MeetupRequest Routen implementiert.
Search Routen habe ich weggelassen, diese mache ich direkt mit dem Service.
Für die get/{id} Methode gibts keine Verwendung im Frontend.
Die delete/{id} Route wird fürs Abmelden verwendet.

Ich habe noch einen AppDialogService erstellt, mit diesem lassen sich die Fehlermeldungen aus der Backendkommunikation aus den Componenten auslagern. So können wir die später einfacher gestalten und anpassen.