### PR TITLE
Feldbreite Hallen Select Suche breite -> dito meetup erfassen

### DIFF
--- a/frontend/src/app/meetup/meetup.component.scss
+++ b/frontend/src/app/meetup/meetup.component.scss
@@ -4,12 +4,3 @@
   width: 180px;
   margin: 1em;
 }
-
-/**
-material Anpassungen
- */
-@media (min-width: $max-xs-width) {
-  .mat-field-large {
-    width: 25em;
-  }
-}

--- a/frontend/src/app/search/search.html
+++ b/frontend/src/app/search/search.html
@@ -20,7 +20,7 @@
           <mat-radio-button value="{{locationType.INDOOR}}">{{ 'search.indoorRadio' | translate }}</mat-radio-button>
           <mat-radio-button value="{{locationType.OUTDOOR}}">{{ 'search.outdoorRadio' | translate }}</mat-radio-button>
         </mat-radio-group>
-        <mat-form-field *ngIf="isIndoor(); else outdoor">
+        <mat-form-field *ngIf="isIndoor(); else outdoor" class="mat-field-large">
           <mat-select formControlName="indoor" placeholder="{{'search.indoor' | translate}}">
             <mat-option *ngFor="let hall of halls" [value]="hall.key">{{hall.name}}</mat-option>
           </mat-select>

--- a/frontend/src/assets/css/general.scss
+++ b/frontend/src/assets/css/general.scss
@@ -69,3 +69,9 @@ mat-radio-group, mat-form-field, mat-table {
 .mat-radio-button {
   padding: 0em 0.5em;
 }
+
+@media (min-width: $max-xs-width) {
+  .mat-field-large {
+    width: 25em;
+  }
+}


### PR DESCRIPTION
Bei der Suche war die Selection für die Halleauswahl schmal, beim erstellen des Meetups jedoch breit. 
Beide auf breit angeglichen.